### PR TITLE
Add newsletters sync and table view

### DIFF
--- a/ui/app/_layout.tsx
+++ b/ui/app/_layout.tsx
@@ -1,12 +1,15 @@
 import { Stack, SplashScreen } from "expo-router";
 import { AuthProvider, useAuth } from "@/hooks/useAuth";
+import { NewslettersProvider } from "@/hooks/useNewsletters";
 
 export default function Root() {
   // Set up the auth context and render our layout inside of it.
   return (
     <AuthProvider>
-      <SplashScreenController />
-      <RootNavigator />
+      <NewslettersProvider>
+        <SplashScreenController />
+        <RootNavigator />
+      </NewslettersProvider>
     </AuthProvider>
   );
 }

--- a/ui/app/newsletters.tsx
+++ b/ui/app/newsletters.tsx
@@ -1,24 +1,37 @@
 import { Text, View } from "react-native";
+import { DataTable, Button } from "react-native-paper";
 
 import { useAuth } from "@/hooks/useAuth";
+import { useNewsletters } from "@/hooks/useNewsletters";
 import { Redirect } from "expo-router";
 
 export default function Index() {
   const { isLoggedIn, clearAuthState } = useAuth();
+  const { newsletters } = useNewsletters();
 
   if (!isLoggedIn) {
     return <Redirect href="/sign-in" />;
   }
 
   return (
-    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-      <Text
-        onPress={() => {
-          clearAuthState();
-        }}
-      >
+    <View style={{ flex: 1, padding: 20 }}>
+      <Button mode="outlined" onPress={clearAuthState} style={{ marginBottom: 20 }}>
         Sign Out
-      </Text>
+      </Button>
+      <DataTable>
+        <DataTable.Header>
+          <DataTable.Title>Title</DataTable.Title>
+          <DataTable.Title>Author</DataTable.Title>
+          <DataTable.Title>Created At</DataTable.Title>
+        </DataTable.Header>
+        {newsletters.map((n) => (
+          <DataTable.Row key={n.id}>
+            <DataTable.Cell>{n.title}</DataTable.Cell>
+            <DataTable.Cell>{n.author}</DataTable.Cell>
+            <DataTable.Cell>{new Date(n.created_at).toLocaleDateString()}</DataTable.Cell>
+          </DataTable.Row>
+        ))}
+      </DataTable>
     </View>
   );
 }

--- a/ui/app/newsletters.tsx
+++ b/ui/app/newsletters.tsx
@@ -1,8 +1,8 @@
-import { Text, View } from "react-native";
-import { DataTable, Button } from "react-native-paper";
+import { View, FlatList } from "react-native";
+import { List, Button } from "react-native-paper";
 
 import { useAuth } from "@/hooks/useAuth";
-import { useNewsletters } from "@/hooks/useNewsletters";
+import { useNewsletters, parseTimestamp } from "@/hooks/useNewsletters";
 import { Redirect } from "expo-router";
 
 export default function Index() {
@@ -15,23 +15,23 @@ export default function Index() {
 
   return (
     <View style={{ flex: 1, padding: 20 }}>
-      <Button mode="outlined" onPress={clearAuthState} style={{ marginBottom: 20 }}>
+      <Button
+        mode="outlined"
+        onPress={clearAuthState}
+        style={{ marginBottom: 20 }}
+      >
         Sign Out
       </Button>
-      <DataTable>
-        <DataTable.Header>
-          <DataTable.Title>Title</DataTable.Title>
-          <DataTable.Title>Author</DataTable.Title>
-          <DataTable.Title>Created At</DataTable.Title>
-        </DataTable.Header>
-        {newsletters.map((n) => (
-          <DataTable.Row key={n.id}>
-            <DataTable.Cell>{n.title}</DataTable.Cell>
-            <DataTable.Cell>{n.author}</DataTable.Cell>
-            <DataTable.Cell>{new Date(n.created_at).toLocaleDateString()}</DataTable.Cell>
-          </DataTable.Row>
-        ))}
-      </DataTable>
+      <FlatList
+        data={newsletters}
+        keyExtractor={(n) => n.id.toString()}
+        renderItem={({ item }) => (
+          <List.Item
+            title={item.title}
+            description={`${item.author} • ${parseTimestamp(item.created_at).toLocaleDateString()}`}
+          />
+        )}
+      />
     </View>
   );
 }

--- a/ui/hooks/useFileStorageState.tsx
+++ b/ui/hooks/useFileStorageState.tsx
@@ -2,16 +2,27 @@ import { useEffect, useCallback, useReducer } from "react";
 import * as FileSystem from "expo-file-system";
 import { Platform } from "react-native";
 
-export type UseFileStorageStateHook<T> = [[boolean, T | null], (value: T | null) => void];
+export type UseFileStorageStateHook<T> = [
+  [boolean, T | null],
+  (value: T | null) => void,
+];
 
-function useAsyncState<T>(initialValue: [boolean, T | null] = [true, null]): UseFileStorageStateHook<T> {
+function useAsyncState<T>(
+  initialValue: [boolean, T | null] = [true, null],
+): UseFileStorageStateHook<T> {
   return useReducer(
-    (_: [boolean, T | null], action: T | null = null): [boolean, T | null] => [false, action],
+    (_: [boolean, T | null], action: T | null = null): [boolean, T | null] => [
+      false,
+      action,
+    ],
     initialValue,
   ) as UseFileStorageStateHook<T>;
 }
 
-async function setSerializedItemAsync<T>(key: string, value: T | null): Promise<void> {
+async function setSerializedItemAsync<T>(
+  key: string,
+  value: T | null,
+): Promise<void> {
   const serialized = value === null ? null : JSON.stringify(value);
   if (Platform.OS === "web") {
     try {
@@ -29,7 +40,9 @@ async function setSerializedItemAsync<T>(key: string, value: T | null): Promise<
       if (serialized === null) {
         await FileSystem.deleteAsync(path, { idempotent: true });
       } else {
-        await FileSystem.writeAsStringAsync(path, serialized, { encoding: FileSystem.EncodingType.UTF8 });
+        await FileSystem.writeAsStringAsync(path, serialized, {
+          encoding: FileSystem.EncodingType.UTF8,
+        });
       }
     } catch (err) {
       console.error("Error writing storage file:", err);
@@ -37,7 +50,9 @@ async function setSerializedItemAsync<T>(key: string, value: T | null): Promise<
   }
 }
 
-export function useFileStorageState<T>(key: string): UseFileStorageStateHook<T> {
+export function useFileStorageState<T>(
+  key: string,
+): UseFileStorageStateHook<T> {
   const [state, setState] = useAsyncState<T>();
 
   useEffect(() => {
@@ -49,7 +64,9 @@ export function useFileStorageState<T>(key: string): UseFileStorageStateHook<T> 
         } else {
           const path = `${FileSystem.documentDirectory ?? ""}${key}.json`;
           if (await FileSystem.getInfoAsync(path).then((info) => info.exists)) {
-            raw = await FileSystem.readAsStringAsync(path, { encoding: FileSystem.EncodingType.UTF8 });
+            raw = await FileSystem.readAsStringAsync(path, {
+              encoding: FileSystem.EncodingType.UTF8,
+            });
           }
         }
         if (raw != null) {
@@ -57,7 +74,10 @@ export function useFileStorageState<T>(key: string): UseFileStorageStateHook<T> 
             const parsed = JSON.parse(raw) as T;
             setState(parsed);
           } catch (parseError) {
-            console.warn(`Failed to parse stored JSON for key "${key}":`, parseError);
+            console.warn(
+              `Failed to parse stored JSON for key "${key}":`,
+              parseError,
+            );
             setState(null);
           }
         } else {

--- a/ui/hooks/useFileStorageState.tsx
+++ b/ui/hooks/useFileStorageState.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useCallback, useReducer } from "react";
+import * as FileSystem from "expo-file-system";
+import { Platform } from "react-native";
+
+export type UseFileStorageStateHook<T> = [[boolean, T | null], (value: T | null) => void];
+
+function useAsyncState<T>(initialValue: [boolean, T | null] = [true, null]): UseFileStorageStateHook<T> {
+  return useReducer(
+    (_: [boolean, T | null], action: T | null = null): [boolean, T | null] => [false, action],
+    initialValue,
+  ) as UseFileStorageStateHook<T>;
+}
+
+async function setSerializedItemAsync<T>(key: string, value: T | null): Promise<void> {
+  const serialized = value === null ? null : JSON.stringify(value);
+  if (Platform.OS === "web") {
+    try {
+      if (serialized === null) {
+        localStorage.removeItem(key);
+      } else {
+        localStorage.setItem(key, serialized);
+      }
+    } catch (e) {
+      console.error("Local storage is unavailable:", e);
+    }
+  } else {
+    const path = `${FileSystem.documentDirectory ?? ""}${key}.json`;
+    try {
+      if (serialized === null) {
+        await FileSystem.deleteAsync(path, { idempotent: true });
+      } else {
+        await FileSystem.writeAsStringAsync(path, serialized, { encoding: FileSystem.EncodingType.UTF8 });
+      }
+    } catch (err) {
+      console.error("Error writing storage file:", err);
+    }
+  }
+}
+
+export function useFileStorageState<T>(key: string): UseFileStorageStateHook<T> {
+  const [state, setState] = useAsyncState<T>();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        let raw: string | null = null;
+        if (Platform.OS === "web") {
+          raw = localStorage.getItem(key);
+        } else {
+          const path = `${FileSystem.documentDirectory ?? ""}${key}.json`;
+          if (await FileSystem.getInfoAsync(path).then((info) => info.exists)) {
+            raw = await FileSystem.readAsStringAsync(path, { encoding: FileSystem.EncodingType.UTF8 });
+          }
+        }
+        if (raw != null) {
+          try {
+            const parsed = JSON.parse(raw) as T;
+            setState(parsed);
+          } catch (parseError) {
+            console.warn(`Failed to parse stored JSON for key "${key}":`, parseError);
+            setState(null);
+          }
+        } else {
+          setState(null);
+        }
+      } catch (error) {
+        console.error("Error accessing storage:", error);
+        setState(null);
+      }
+    };
+
+    load();
+  }, [key]);
+
+  const setValue = useCallback(
+    (value: T | null) => {
+      setState(value);
+      setSerializedItemAsync(key, value);
+    },
+    [key],
+  );
+
+  return [state, setValue];
+}

--- a/ui/hooks/useNewsletters.tsx
+++ b/ui/hooks/useNewsletters.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useFileStorageState } from "@/hooks/useFileStorageState";
 
-function parseTimestamp(ts: string): Date {
+export function parseTimestamp(ts: string): Date {
   const [date, timeZone] = ts.split(" ");
   let [time] = timeZone.split("+");
   if (time.includes(".")) {
@@ -37,7 +37,9 @@ const NewslettersContext = createContext<NewslettersContextValue>({
 export function useNewsletters() {
   const value = use(NewslettersContext);
   if (!value) {
-    throw new Error("useNewsletters must be wrapped in a <NewslettersProvider />");
+    throw new Error(
+      "useNewsletters must be wrapped in a <NewslettersProvider />",
+    );
   }
   return value;
 }
@@ -95,8 +97,10 @@ export function NewslettersProvider({ children }: PropsWithChildren) {
           all.push(...validItems);
           if (
             data.result.length < 100 ||
-            parseTimestamp(data.result[data.result.length - 1]?.updated_at ?? "1970-01-01 00:00:00+00") <
-              threeMonthsAgo
+            parseTimestamp(
+              data.result[data.result.length - 1]?.updated_at ??
+                "1970-01-01 00:00:00+00",
+            ) < threeMonthsAgo
           ) {
             break;
           }
@@ -122,7 +126,9 @@ export function NewslettersProvider({ children }: PropsWithChildren) {
   }, [authState, setNewsletters]);
 
   return (
-    <NewslettersContext.Provider value={{ newsletters: newsletters ?? [], isLoading: loading }}>
+    <NewslettersContext.Provider
+      value={{ newsletters: newsletters ?? [], isLoading: loading }}
+    >
       {children}
     </NewslettersContext.Provider>
   );

--- a/ui/hooks/useNewsletters.tsx
+++ b/ui/hooks/useNewsletters.tsx
@@ -1,0 +1,119 @@
+import { use, createContext, type PropsWithChildren } from "react";
+import { useEffect } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { useStorageState } from "@/hooks/useStorageState";
+
+export interface Newsletter {
+  id: number;
+  title: string;
+  author: string;
+  filename: string;
+  read: boolean;
+  deleted: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface NewslettersContextValue {
+  newsletters: Newsletter[];
+  isLoading: boolean;
+}
+
+const NewslettersContext = createContext<NewslettersContextValue>({
+  newsletters: [],
+  isLoading: false,
+});
+
+export function useNewsletters() {
+  const value = use(NewslettersContext);
+  if (!value) {
+    throw new Error("useNewsletters must be wrapped in a <NewslettersProvider />");
+  }
+  return value;
+}
+
+export function NewslettersProvider({ children }: PropsWithChildren) {
+  const { state: authState } = useAuth();
+  const [[loading, newsletters], setNewsletters] =
+    useStorageState<Newsletter[]>("newsletters");
+
+  useEffect(() => {
+    if (!authState) {
+      setNewsletters([]);
+      return;
+    }
+    const { host, jwt } = authState;
+
+    let cancelled = false;
+
+    async function sync() {
+      const all: Newsletter[] = [];
+      let beforeTimestamp: string | undefined;
+      let beforeId: number | undefined;
+      const threeMonthsAgo = new Date();
+      threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+
+      while (true) {
+        const params = new URLSearchParams();
+        if (beforeTimestamp && beforeId !== undefined) {
+          params.append("before_timestamp", beforeTimestamp);
+          params.append("before_id", beforeId.toString());
+        }
+        const url = `${host}/newsletters?${params.toString()}`;
+        try {
+          const resp = await fetch(url, {
+            headers: { Authorization: `Bearer ${jwt}` },
+          });
+          if (!resp.ok) {
+            console.warn("Failed to fetch newsletters", resp.status);
+            break;
+          }
+          const data = (await resp.json()) as {
+            meta: any;
+            result: Newsletter[];
+          };
+          if (
+            (beforeTimestamp || beforeId !== undefined) &&
+            (data.meta.before_timestamp !== beforeTimestamp ||
+              data.meta.before_id !== beforeId)
+          ) {
+            console.warn("Pagination parameters not echoed back correctly");
+          }
+          const validItems = data.result.filter(
+            (n) => new Date(n.updated_at) >= threeMonthsAgo,
+          );
+          all.push(...validItems);
+          if (
+            data.result.length < 50 ||
+            new Date(data.result[data.result.length - 1]?.updated_at ?? 0) <
+              threeMonthsAgo
+          ) {
+            break;
+          }
+          const last = data.result[data.result.length - 1];
+          beforeTimestamp = last.updated_at;
+          beforeId = last.id;
+        } catch (e) {
+          console.error("Error syncing newsletters", e);
+          break;
+        }
+      }
+
+      if (!cancelled) {
+        setNewsletters(all);
+      }
+    }
+
+    sync();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authState, setNewsletters]);
+
+  return (
+    <NewslettersContext.Provider value={{ newsletters: newsletters ?? [], isLoading: loading }}>
+      {children}
+    </NewslettersContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- sync newsletters after login and store in secure storage
- expose newsletter data via NewslettersProvider
- show newsletter list with signout button

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `rake server:spec` *(fails: connection to server at "::1" failed)*

------
https://chatgpt.com/codex/tasks/task_b_687b16209e80832faf0ad29c071e98f4