### PR TITLE
Add newsletter downloader

### DIFF
--- a/ui/app/newsletters.tsx
+++ b/ui/app/newsletters.tsx
@@ -6,6 +6,12 @@ import { useNewsletters, parseTimestamp } from "@/hooks/useNewsletters";
 import { Redirect, Stack, useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const statusIcons: Record<"pending" | "downloading" | "downloaded", string> = {
+  pending: "cloud-download-outline",
+  downloading: "progress-download",
+  downloaded: "check-circle-outline",
+};
+
 export default function Index() {
   const { isLoggedIn, clearAuthState } = useAuth();
   const {
@@ -95,7 +101,12 @@ export default function Index() {
             title={item.title}
             titleNumberOfLines={0}
             descriptionNumberOfLines={0}
-            right={() => <Icon source="cloud-download-outline" size={20} />}
+            right={() => (
+              <Icon
+                source={statusIcons[item.downloadStatus ?? "pending"]}
+                size={20}
+              />
+            )}
           />
         )}
       />

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "expo-file-system": "~15.5.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- extend newsletters to track download status
- add downloader to fetch unread newsletters in order
- show status icons in the UI
- save downloads using expo-file-system
- add expo-file-system dependency
- remove filename parameter and cleanup old files

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_687c4253cf88832fb797de9e6ce5b95f